### PR TITLE
fix: possible time error

### DIFF
--- a/components/transactions/components/AllTransactions.tsx
+++ b/components/transactions/components/AllTransactions.tsx
@@ -72,15 +72,21 @@ const AllTransactions = () => {
       ),
       dataIndex: "time",
       key: "time",
-      render: (timestamp) => (
-        <span>
-          {showDate
-            ? format(parseISO(timestamp), "yyyy-LL-dd kk:mm:ss")
-            : formatDistanceToNow(parseISO(timestamp), {
-                addSuffix: true,
-              })}
-        </span>
-      ),
+      render: (timestamp) => {
+        try {
+          return (
+            <span>
+              {showDate
+                ? format(parseISO(timestamp), "yyyy-LL-dd kk:mm:ss")
+                : formatDistanceToNow(parseISO(timestamp), {
+                    addSuffix: true,
+                  })}
+            </span>
+          );
+        } catch (err) {
+          return "";
+        }
+      },
     },
     {
       title: "From",


### PR DESCRIPTION
When parsing an invalid date, date-fns library will throw the error "Invalid time value".