### PR TITLE
fix/companion-wallet-qa

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <title>Companion wallet</title>
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/components/common/formField/style.module.css
+++ b/components/common/formField/style.module.css
@@ -15,6 +15,7 @@
   flex: 1;
   font-size: 14px;
   font-weight: 400;
+  word-break: break-all;
 }
 
 .noValue {

--- a/components/index.html
+++ b/components/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>My Parcel App</title>
+    <title>Companion wallet</title>
   </head>
   <body>
     <div id="app"></div>

--- a/components/overview/index.tsx
+++ b/components/overview/index.tsx
@@ -10,6 +10,7 @@ import CopyToClipboard from '@/components/common/copyToClipboard';
 import AddressVerification from '@/components/transactions/components/AddressVerification';
 import Details from '@/components/common/details';
 import useSnackbar from '@/utils/snackbar';
+import {formatNumber} from '@/utils';
 import {HD_DERIVATION_PATH, ERROR_CODE} from "@/constants";;
 import styles from './style.module.css';
 
@@ -68,7 +69,7 @@ function Overview({
       title='Account Balance'
       subtitle={<Button type="link" href={`${explorerUrl}/address/ELF_${address}_AELF#txns`} target="_blank" className={styles.btnNoSpacing}>View All Txns</Button>}>
       <Space className={styles.spaceIndent}>
-        <Typography.Text className={styles.balanceValue}>{balance}</Typography.Text>
+        <Typography.Text className={styles.balanceValue}>{formatNumber(balance)}</Typography.Text>
         <Typography.Text className={styles.balanceLabel}>ELF</Typography.Text>
       </Space>
       <div className={styles.accountLayout}>

--- a/components/transactions/components/AllTransactions.tsx
+++ b/components/transactions/components/AllTransactions.tsx
@@ -11,6 +11,7 @@ import { explorerUrlState } from "@/state/selector";
 import { addressState } from "@/state";
 import PaperLayout from '@/components/common/paperLayout'
 import CopyToClipboard from '@/components/common/copyToClipboard'
+import {MIN_TRANSACTIONS_TO_SHOW_EXPLORER_LINK} from '@/utils/constants';
 import rightArrowImage from '@/assets/icon/right-arrow.svg';
 import rightArrowSuccessImage from '@/assets/icon/right-arrow-success.svg';
 import { List } from "../../../app/transactions/route";
@@ -140,7 +141,7 @@ const AllTransactions = () => {
         onChange={(pagination) => setPagination(pagination)}
         size="middle"
       />
-      {data?.list.length > 8 && <Flex justify='center' align='center' className={styles.btnContainer}>
+      {data?.list.length > MIN_TRANSACTIONS_TO_SHOW_EXPLORER_LINK && <Flex justify='center' align='center' className={styles.btnContainer}>
         <a className={styles.btn} href={`${explorerUrl}/address/ELF_${address}_AELF#tokentxns`} target="_blank">
           View all transactions on AELF Explorer
         </a>&nbsp;<Image src={rightArrowImage} alt="Copy to the clipboard"/>

--- a/components/transactions/components/AllTransactions.tsx
+++ b/components/transactions/components/AllTransactions.tsx
@@ -140,11 +140,11 @@ const AllTransactions = () => {
         onChange={(pagination) => setPagination(pagination)}
         size="middle"
       />
-      <Flex justify='center' align='center' className={styles.btnContainer}>
-        <a className={styles.btn} href={`${explorerUrl}/address/ELF_${address}_AELF#txns`} target="_blank">
+      {data?.list.length > 8 && <Flex justify='center' align='center' className={styles.btnContainer}>
+        <a className={styles.btn} href={`${explorerUrl}/address/ELF_${address}_AELF#tokentxns`} target="_blank">
           View all transactions on AELF Explorer
         </a>&nbsp;<Image src={rightArrowImage} alt="Copy to the clipboard"/>
-      </Flex>
+      </Flex>}
     </PaperLayout>
   );
 };

--- a/components/transactions/components/SendTransaction.tsx
+++ b/components/transactions/components/SendTransaction.tsx
@@ -153,8 +153,10 @@ function SendTransaction({
       const res2 = await signAndSendTransaction(rawTx);
 
       setTransactionId(res2.TransactionId);
-
       if (res2.TransactionId) {
+        setFormData({to: '', amount: '', memo: ''});
+        form.setFieldsValue({to: '', amount: '', memo: ''});
+        setAmountValue(null);
         setShowSuccessModal(true);
       }
     } catch (err) {
@@ -261,6 +263,14 @@ function SendTransaction({
                   stringMode
                   parser={(value) => value.replace(/[\s$,]/g, "")}
                   onChange={setAmountValue}
+                  onStep={(value, stepObj: any) => {
+                    setAmountValue(value);
+                    form.setFieldsValue({ amount: value });
+                    setFormData({...formData, amount: value});
+                    if (stepObj.type === 'up' || stepObj.type === 'down') {
+                      form.validateFields(['amount']);
+                    }
+                  }}
                 />
                 {amountValue !== null && (
                   <CloseCircleFilled className={styles.clearIcon} onClick={() => {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -4,3 +4,5 @@ export const ERROR_CODE = {
     DEVICE_LOCKED: 'LockedDeviceError',
     CROSS_CHAIN: 'InvalidCrossChain'
 };
+
+export const MIN_TRANSACTIONS_TO_SHOW_EXPLORER_LINK = 8;

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -10,3 +10,13 @@ export const replaceAll = (str: string, find: string, replace: string) => {
   const regex = new RegExp(find, 'g');
   return str.replace(regex, replace);
 }
+
+export const formatNumber = (value: string) => {
+  const [integerPart, decimalPart = ''] = value.split('.');
+
+  if (decimalPart.replace(/0/g, '').length > 0) {
+    return value;
+  } else {
+    return integerPart;
+  }
+}

--- a/utils/validateAddress.ts
+++ b/utils/validateAddress.ts
@@ -22,6 +22,9 @@ export const validateAddress = (
   try {
     bs58.decode(mid);
     decodeAddressRep(mid);
+    if (!/^[a-zA-Z0-9]+$/.test(mid)) {
+      throw new Error("Oops! Please input a valid AELF network address!");
+    }
   } catch (err) {
     throw new Error("Oops! Please input a valid AELF network address!");
   }


### PR DESCRIPTION
Following ticket has been fixed:

- Write Chinese in To address text box，click button, there is no prompt.
- Fill in the amount through the arrow in the amount text box, Transfer now cannot be clicked.
- Enter 64 characters in the memo text box,  The contents of the memo are not aligned with the rest of the current column in Transaction Summary popup.
- Click 'View all transactions on AELF Explorer' link at the bottom of the page, new page should focus on token transfers, because the data is same with token transfers.
- After transfer，the content of to text box and amount text box is not cleared.
- When the data is less than or equal to 8, 'View all transactions on AELF Explorer' link should not be displayed.
- Current chain is main, write address with main part and prefix in to address text box prompt oops.
- If the account balance is a whole number,  should show only integers, not decimals.
